### PR TITLE
Chore: Add license and repo to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,11 @@ setup(
     ),
     author="Francois Chollet",
     author_email="francois.chollet@gmail.com",
+    url="https://github.com/fchollet/namex",
+    license="Apache License 2.0",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+    ],
     packages=find_packages(),
 )


### PR DESCRIPTION
Added some basic documentation to setup.py
This adds a link to the GitHub repo so that users on PyPI can easily refer to the source code, as well as including the license.