### PR TITLE
declare license in package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(
     ),
     author="Francois Chollet",
     author_email="francois.chollet@gmail.com",
+    license="Apache License 2.0",
     packages=find_packages(),
 )


### PR DESCRIPTION
I noticed that `keras` depends on `namex`, but `namex` does not declare a license (see `pip-licenses | grep namex`).