### PR TITLE
Use a valid SPDX identifier as license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(
     ),
     author="Francois Chollet",
     author_email="francois.chollet@gmail.com",
+    license="Apache-2.0",
     packages=find_packages(),
 )


### PR DESCRIPTION
This helps automatic license checkers like pip-licenses to identify the right license for this project

Refs #2 