### PR TITLE
Add license info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(
     ),
     author="Francois Chollet",
     author_email="francois.chollet@gmail.com",
+    license="Apache-2.0",
     packages=find_packages(),
 )


### PR DESCRIPTION
Adds license specifiers according to https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

This allows automatic license inspection tools like pip-licenses to correctly categorize this package.